### PR TITLE
in tekton, change cluster namespace to prod

### DIFF
--- a/.bluemix/toolchain.yml
+++ b/.bluemix/toolchain.yml
@@ -126,7 +126,6 @@ form:
   pipeline:
     parameters:
       app-name: "{{services.repo.parameters.repo_name}}"
-      prod-cluster-namespace: >
-        $env.pipeline_type === 'tekton' ? 'default' : 'prod'
+      prod-cluster-namespace: prod
     schema:
       $ref: deploy.json


### PR DESCRIPTION
the prod-cluster-namespace
was 'default' for pipeline type tekton
and 'prod' for type classic,
but changing to 'prod' for both,
to be consistent and for
ease of cleanup / delete namespace
after testing