### PR TITLE
fix: form section

### DIFF
--- a/.bluemix/toolchain.yml
+++ b/.bluemix/toolchain.yml
@@ -188,7 +188,17 @@ services:
 form:
   pipeline:
     parameters:
-      app-name: "{{services.repo.parameters.repo_name}}"
-      prod-cluster-namespace: prod
+      app-name: >
+        $env.appName ?
+          '{{appName}}' : '{{services.repo.parameters.repo_name}}'
+      prod-cluster-namespace: >
+        $env.prodClusterNamespace ?
+          '{{prodClusterNamespace}}' : 'prod'
+      registry-region: '{{registryRegion}}'
+      registry-namespace: '{{registryNamespace}}'
+      api-key: '{{apiKey}}'
+      prod-region: '{{prodRegion}}'
+      prod-resource-group: '{{prodResourceGroup}}'
+      prod-cluster-name: '{{prodClusterName}}'
     schema:
       $ref: deploy.json


### PR DESCRIPTION
Without these additional parameters, an attempt to create a headless toolchain results in the following error:  
`(local-exec): {"status":"error","description":"Failed Schema Validation at api-key,registry-region,registry-namespace,prod-region,prod-resource-group,prod-cluster-name for pipeline","details":""}`  
Also, could you make some of the other fields match those in the toolchain.yml from the simple-helm-toolchain, which use env vars for certain values?
https://github.com/open-toolchain/simple-helm-toolchain/blob/master/.bluemix/toolchain.yml