### PR TITLE
Fix devops insights actions

### DIFF
--- a/.bluemix/conditions.yml
+++ b/.bluemix/conditions.yml
@@ -179,7 +179,7 @@ tools_conditions:
     actions:
       - type: create-service
         service_id: draservicebroker
-        service_label: doi
+        service_label: devops-insights
   - condition:
       any:
         - parameter: doi
@@ -187,4 +187,4 @@ tools_conditions:
     actions:
       - type: delete-service
         service_id: draservicebroker
-        service_label: doi
+        service_label: devops-insights


### PR DESCRIPTION
Found whilst working on the e2e test for wizard SKT template. The service labels were wrong in the actions for adding/removing the devops insights tool. Update to fix the labels